### PR TITLE
DM-29740: Create theme component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # discourse-alt-lock-icon
-Discourse theme component that swaps the private category icon (lock) for an unlock icon.
+
+Discourse theme component that swaps the private category icon (lock) for an unlock icon (Font Awesome's `unlock-alt`). This icon makes a bit more semantic sense because it means that the category is "unlocked" and therefore viewable for a user.

--- a/about.json
+++ b/about.json
@@ -1,0 +1,6 @@
+{
+  "name": "Alt lock icon",
+  "about_url": "https://github.com/lsst-sqre/discourse-alt-lock-icon/blob/main/README.md",
+  "license_url": "https://github.com/lsst-sqre/discourse-alt-lock-icon/blob/main/LICENSE",
+  "component": true
+}

--- a/common/header.html
+++ b/common/header.html
@@ -1,0 +1,3 @@
+<script type="text/discourse-plugin" version="0.8">
+  api.replaceIcon('lock', 'unlock-alt');
+</script>


### PR DESCRIPTION
This theme component replaces the "lock" icon with "unlock-alt".

In this manner, it transforms the icon for private categories from Font Awesome's "lock" to FA's "unlock-alt".

This makes a bit more semantic sense because it means that the category is "unlocked" and therefore viewable for a user.

Related discussion: https://community.lsst.org/t/should-we-change-the-lock-icon-for-restricted-categories/4702